### PR TITLE
Add error event when negotiation fails

### DIFF
--- a/lib/negotiator.js
+++ b/lib/negotiator.js
@@ -146,8 +146,12 @@ Negotiator._setupListeners = function(connection, pc, pc_id) {
 
   pc.oniceconnectionstatechange = function() {
     switch (pc.iceConnectionState) {
-      case 'disconnected':
       case 'failed':
+        util.log('iceConnectionState is disconnected, closing connections to ' + peerId);
+        connection.emit('error', new Error('Negotiation of connection to ' + peerId + ' failed.'));
+        connection.close();
+        break;
+      case 'disconnected':
         util.log('iceConnectionState is disconnected, closing connections to ' + peerId);
         connection.close();
         break;


### PR DESCRIPTION
When negotiation fails, it fails silently, neither closed or error is
emitted on the connection. Thus, there is no way to know if the
connection negotiation failed.
